### PR TITLE
heartbeat

### DIFF
--- a/terminal_app/Cargo.toml
+++ b/terminal_app/Cargo.toml
@@ -10,6 +10,7 @@ edition = "2021"
 mac_address = "1.1.4"
 sqlx = { version = "0.6.2", features = [ "runtime-async-std-native-tls", "sqlite" ] }
 async-std = { version = "1.10", features = [ "attributes" ] }
+async-recursion = "1.0.0"
 futures = { version = "0.3.25" }
 futures-timer = { version ="3.0" }
-
+zmq = "0.10.0"

--- a/terminal_app/Cargo.toml
+++ b/terminal_app/Cargo.toml
@@ -10,7 +10,6 @@ edition = "2021"
 mac_address = "1.1.4"
 sqlx = { version = "0.6.2", features = [ "runtime-async-std-native-tls", "sqlite" ] }
 async-std = { version = "1.10", features = [ "attributes" ] }
-async-recursion = "1.0.0"
 futures = { version = "0.3.25" }
 futures-timer = { version ="3.0" }
 zmq = "0.10.0"

--- a/terminal_app/src/main.rs
+++ b/terminal_app/src/main.rs
@@ -1,5 +1,8 @@
 mod models;
 mod services;
+use std::env;
+use async_recursion::async_recursion;
+use std::{thread, time::Duration};
 use mac_address::MacAddress;
 use mac_address::get_mac_address;
 use futures::executor::block_on;
@@ -18,7 +21,43 @@ fn get_mac() -> MacAddress {
     }
 }
 
+#[async_recursion(?Send)]
+async fn build_heartbeat(mut backoff: u64) {
+    thread::sleep(Duration::from_secs(backoff));
+    
+    let default_url: &str = "tcp://localhost:3001";
+    let context = zmq::Context::new();
+    let p = context.socket(zmq::PUB).unwrap();
+    
+    let connection_url: String;
+    match env::var("heartbeat_url") {
+        Ok(url) => connection_url = url,
+        Err(_) => connection_url = default_url.to_string()
+    }
+
+    match p.connect(&connection_url) {
+        Ok(_) => (),
+        Err(_) => {
+            backoff *= 2;
+            if backoff > 128 { backoff = 128 } else if backoff == 0 { backoff = 1 }
+            println!("ZMQ Error. Attempting to reconnect in {} seconds", backoff);
+            build_heartbeat(backoff).await;
+        }
+    }
+
+    let client: Heartbeat = Heartbeat { mac_address: get_mac().to_string() };
+    
+    loop {
+        println!("sending");
+        p.send(&client.mac_address, 0).unwrap();
+        thread::sleep(Duration::from_secs(10));
+        backoff = 0;
+    }
+}
+
 fn main() {
+    build_heartbeat(0);
+
     // Just a small example of how to use the models
     let beat: Heartbeat = Heartbeat { mac_address: get_mac().to_string() };
     let check_in: Checkin = Checkin { mac_address: beat.mac_address, student_id: "12345".to_string() };
@@ -29,5 +68,5 @@ fn main() {
     let db_url = "sqlite://cache.db";
     block_on(initialize_database(db_url));
     block_on(insert_check_in(db_url, &check_in));
-    //block_on(delete_check_in(db_url, &check_in.student_id));
+    block_on(delete_check_in(db_url, &check_in.student_id));
 }

--- a/terminal_app/src/main.rs
+++ b/terminal_app/src/main.rs
@@ -46,8 +46,8 @@ fn build_heartbeat(mut backoff: u64, lock: Arc<Mutex<i8>>) {
         }
         
         let client: Heartbeat = Heartbeat { mac_address: get_mac().to_string() };
-    
-        match proxy.send(client.mac_address.as_bytes(), 0) {
+        let data = format!("heartbeat {}", client.mac_address);
+        match proxy.send(data.as_bytes(), 0) {
             Ok(_) => println!("sent heartbeat"),
             Err(_) => {
                 backoff *= 2;

--- a/terminal_app/src/main.rs
+++ b/terminal_app/src/main.rs
@@ -3,7 +3,7 @@ mod services;
 use services::cache::*;
 use zmq::{Context, Socket};
 use futures::executor::block_on;
-use std::{env, thread, time::Duration};
+use std::{env, thread, time::Duration, sync::{Arc, Mutex}};
 use models::{heartbeat::*, checkin::*};
 use mac_address::{MacAddress, get_mac_address};
 
@@ -18,40 +18,43 @@ fn get_mac() -> MacAddress {
     }
 }
 
-fn build_heartbeat(mut backoff: u64) {
+fn build_heartbeat(mut backoff: u64, lock: Arc<Mutex<i8>>) {
     thread::sleep(Duration::from_secs(backoff));
-    
-    let default_url: &str = "tcp://localhost:9951";
-    let context: Context = zmq::Context::new();
-    let proxy: Socket = context.socket(zmq::PUB).unwrap();
 
-    let connection_url: String;
-    match env::var("heartbeat_url") {
-        Ok(url) => connection_url = url,
-        Err(_) => connection_url = default_url.to_string()
-    }
-
-    match proxy.connect(&connection_url) {
-        Ok(_) => println!("connected"),
-        Err(_) => {
-            backoff *= 2;
-            if backoff > 128 { backoff = 128 } else if backoff == 0 { backoff = 1 }
-            println!("ZMQ Error. Attempting to reconnect in {} seconds", backoff);
-            thread::spawn(move || {build_heartbeat(backoff)});
-            return;
-        }
-    }
-    
-    let client: Heartbeat = Heartbeat { mac_address: get_mac().to_string() };
-    
     loop {
+        let mutex_lock = lock.lock().unwrap();
+        let default_url: &str = "tcp://localhost:9951";
+        let context: Context = zmq::Context::new();
+        let proxy: Socket = context.socket(zmq::PUB).unwrap();
+
+        let connection_url: String;
+        match env::var("heartbeat_url") {
+            Ok(url) => connection_url = url,
+            Err(_) => connection_url = default_url.to_string()
+        }
+
+        match proxy.connect(&connection_url) {
+            Ok(_) => println!("connected"),
+            Err(_) => {
+                backoff *= 2;
+                if backoff > 128 { backoff = 128 } else if backoff == 0 { backoff = 1 }
+                println!("ZMQ Error. Attempting to reconnect in {} seconds", backoff);
+                std::mem::drop(mutex_lock);
+                thread::spawn(move || {build_heartbeat(backoff, lock)});
+                return;
+            }
+        }
+        
+        let client: Heartbeat = Heartbeat { mac_address: get_mac().to_string() };
+    
         match proxy.send(client.mac_address.as_bytes(), 0) {
             Ok(_) => println!("sent heartbeat"),
             Err(_) => {
                 backoff *= 2;
                 if backoff > 128 { backoff = 128 } else if backoff == 0 { backoff = 1 }
                 println!("ZMQ Error. Attempting to reconnect in {} seconds", backoff);
-                thread::spawn(move || {build_heartbeat(backoff)});
+                std::mem::drop(mutex_lock);
+                thread::spawn(move || {build_heartbeat(backoff, lock)});
                 return;
             }
         }
@@ -61,7 +64,13 @@ fn build_heartbeat(mut backoff: u64) {
 }
 
 fn main() {
-    let heartbeat_handle = thread::spawn(|| {build_heartbeat(0)});
+    // Mutex required for Windows as heartbeat and sqlite try to use the same memory location at the same time
+    let mutex_lock = Arc::new(Mutex::new(0));
+    let tread_arc_0 = mutex_lock.clone();
+    let tread_arc_1 = mutex_lock.clone();
+    let tread_arc_2 = mutex_lock.clone();
+
+    let heartbeat_handle = thread::spawn(move || {build_heartbeat(0, mutex_lock.clone())});
     // Just a small example of how to use the models
     let beat: Heartbeat = Heartbeat { mac_address: get_mac().to_string() };
     let check_in: Checkin = Checkin { mac_address: beat.mac_address, student_id: "12345".to_string() };
@@ -70,8 +79,8 @@ fn main() {
     // Example of cache
     // Use https://sqliteviewer.app/#/ to observe the sql table
     let db_url = "sqlite://cache.db";
-    block_on(initialize_database(db_url));
-    block_on(insert_check_in(db_url, &check_in));
-    block_on(delete_check_in(db_url, &check_in.student_id));
+    block_on(initialize_database(db_url, tread_arc_0));
+    block_on(insert_check_in(db_url, &check_in, tread_arc_1));
+    block_on(delete_check_in(db_url, &check_in.student_id, tread_arc_2));
     let _heartbeat_res = heartbeat_handle.join();
 }

--- a/terminal_app/src/main.rs
+++ b/terminal_app/src/main.rs
@@ -1,14 +1,12 @@
 mod models;
 mod services;
-use std::env;
-use async_recursion::async_recursion;
-use std::{thread, time::Duration};
-use mac_address::MacAddress;
-use mac_address::get_mac_address;
-use futures::executor::block_on;
-use models::heartbeat::*;
-use models::checkin::*;
 use services::cache::*;
+use zmq::{Context, Socket};
+use futures::executor::block_on;
+use async_recursion::async_recursion;
+use std::{env, thread, time::Duration};
+use models::{heartbeat::*, checkin::*};
+use mac_address::{MacAddress, get_mac_address};
 
 fn get_mac() -> MacAddress {
     // gets the mac_address and returns it
@@ -25,18 +23,21 @@ fn get_mac() -> MacAddress {
 async fn build_heartbeat(mut backoff: u64) {
     thread::sleep(Duration::from_secs(backoff));
     
-    let default_url: &str = "tcp://localhost:3001";
-    let context = zmq::Context::new();
-    let p = context.socket(zmq::PUB).unwrap();
+    let default_url: &str = "tcp://localhost:9951";
+    let context: Context = zmq::Context::new();
+    let proxy: Socket = context.socket(zmq::PUB).unwrap();
     
+    println!("Trying to get env");
     let connection_url: String;
     match env::var("heartbeat_url") {
         Ok(url) => connection_url = url,
         Err(_) => connection_url = default_url.to_string()
     }
 
-    match p.connect(&connection_url) {
-        Ok(_) => (),
+    println!("{}", connection_url);
+
+    match proxy.connect(&connection_url) {
+        Ok(_) => println!("connected"),
         Err(_) => {
             backoff *= 2;
             if backoff > 128 { backoff = 128 } else if backoff == 0 { backoff = 1 }
@@ -45,11 +46,20 @@ async fn build_heartbeat(mut backoff: u64) {
         }
     }
 
+    println!("{}", proxy.get_socks_proxy().unwrap().unwrap());
+    
     let client: Heartbeat = Heartbeat { mac_address: get_mac().to_string() };
     
     loop {
-        println!("sending");
-        p.send(&client.mac_address, 0).unwrap();
+        match proxy.send(client.mac_address.as_bytes(), 0) {
+            Ok(_) => println!("sent heartbeat"),
+            Err(_) => {
+                backoff *= 2;
+                if backoff > 128 { backoff = 128 } else if backoff == 0 { backoff = 1 }
+                println!("ZMQ Error. Attempting to reconnect in {} seconds", backoff);
+                build_heartbeat(backoff).await;
+            }
+        }
         thread::sleep(Duration::from_secs(10));
         backoff = 0;
     }


### PR DESCRIPTION
This one function caused quite a few problems. I had to include mutex locks for our windows implementation even it would work just fine on Linux. Basically our heartbeat and cache were both using ZMQ and both trying to use the same memory location. Each set of functions would work on their own, but not together so the mutex prevents any issues. I tested on both windows and Linux and they worked. This is one of those issues I need you to test before approving. Just run for a bit of time and as long as it doesn't crash and you see multiple "heartbeat sent" then it should be good.